### PR TITLE
New adopter fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+Matterhorn2GO
+=============
+
+Matterhorn2GO LGPL-License
+
+http://vm193.rz.uni-osnabrueck.de/matterhorn2go/index_en.html
+
+Lecture recordings on the way!
+
+ Opencast Matterhorn is an opensource lecture recording system used by 
+many universities all over the world. Matterhorn can record the video 
+of the lecturer and also the computer screen. This app allows you to 
+watch both videos side by side or to choose one of them. 
+More information all about Matterhorn can be found here: 
+
+http://opencast.org/matterhorn/. 
+
+With this app you can select between the Matterhorn installations 
+of registered universities.

--- a/src/views/AddLocalAdopterView.mxml
+++ b/src/views/AddLocalAdopterView.mxml
@@ -34,7 +34,7 @@ USA
 			import business.datahandler.EpisodesDataHandler;
 			import business.datahandler.SeriesDataHandler;
 			import business.datahandler.URLClass;
-			import business.datahandler.did.CustomURLHandler;
+			//import business.datahandler.did.CustomURLHandler;
 			import business.dbaccess.SQLEditHandler;
 			
 			import events.FileReaderCompleteEvent;
@@ -54,7 +54,7 @@ USA
 			
 			private var dH:EpisodesDataHandler;
 			
-			private var url:CustomURLHandler;
+			//private var url:CustomURLHandler;
 			
 			[Bindable]
 			protected var height_num:Number = 0;
@@ -172,8 +172,8 @@ USA
 				var aU:SQLEditHandler = SQLEditHandler.getInstance();
 				
 				if(e == null) {
-					url = CustomURLHandler.getInstance();
-					url.setCustomURL(textinput_url.text);
+					//url = CustomURLHandler.getInstance();
+					//url.setCustomURL(textinput_url.text);
 					aU.insertAdopter(textinput_name.text, cURL);
 					
 					navigator.popView();
@@ -183,8 +183,8 @@ USA
 					if(!ok) 
 					{
 						ok = true;
-						url = CustomURLHandler.getInstance();
-						url.setCustomURL(textinput_url.text);
+						//url = CustomURLHandler.getInstance();
+						//url.setCustomURL(textinput_url.text);
 						aU.insertAdopter(textinput_name.text, cURL);
 					}
 				}

--- a/src/views/ConfigurationView.mxml
+++ b/src/views/ConfigurationView.mxml
@@ -145,6 +145,8 @@ USA
 				
 				// verifying your url 
 				var cURL:String = textinput_url.text;
+
+				var protocol:String = "http://";
 				
 				var pattern:RegExp = /http:\/\//i;
 				
@@ -158,6 +160,7 @@ USA
 				if(pattern2.test(cURL))
 				{
 					cURL = cURL.split(pattern2)[1];
+					protocol = "https://";
 				}	
 				
 				var pattern3:RegExp = /(\d+)/g;
@@ -167,7 +170,7 @@ USA
 
 				cURL = cURL.replace(pattern3, "$1");
 
-				cURL = "http://"+cURL;
+				cURL = protocol + cURL;
 				// end of verifying
 
 				fileReader.setURL(cURL, true);

--- a/src/views/ConfigurationView.mxml
+++ b/src/views/ConfigurationView.mxml
@@ -35,7 +35,7 @@ USA
 			import business.datahandler.SeriesDataHandler;
 			import business.datahandler.URLClass;
 			import business.datahandler.XMLHandler;
-			import business.datahandler.did.CustomURLHandler;
+			//import business.datahandler.did.CustomURLHandler;
 			import business.dbaccess.SQLEditHandler;
 			
 			import events.FileReaderCompleteEvent;

--- a/src/views/ConfigurationView.mxml
+++ b/src/views/ConfigurationView.mxml
@@ -146,31 +146,15 @@ USA
 				// verifying your url 
 				var cURL:String = textinput_url.text;
 
-				var protocol:String = "http://";
+				// Check if the given URL has a valid protocol.
+				// Users often omit them (stupid users).
+				// If no protocol is given, we assume that we should use HTTP.
+				var pattern:RegExp = /https{0,1}:\/\//i;
 				
-				var pattern:RegExp = /http:\/\//i;
-				
-				if(pattern.test(cURL))
+				if(!pattern.test(cURL))
 				{
-					cURL = cURL.split(pattern)[1];
+					cURL = "http://" + cURL;
 				}	  
-				
-				var pattern2:RegExp = /https:\/\//i;
-				
-				if(pattern2.test(cURL))
-				{
-					cURL = cURL.split(pattern2)[1];
-					protocol = "https://";
-				}	
-				
-				var pattern3:RegExp = /(\d+)/g;
-				var re0:RegExp = /(\/\w*)/i;
-
-				cURL = cURL.split(re0)[0];
-
-				cURL = cURL.replace(pattern3, "$1");
-
-				cURL = protocol + cURL;
 				// end of verifying
 
 				fileReader.setURL(cURL, true);

--- a/src/views/EpisodeView.mxml
+++ b/src/views/EpisodeView.mxml
@@ -36,7 +36,7 @@ USA
 			import business.datahandler.EpisodesDataHandler;
 			import business.datahandler.SeriesDataHandler;
 			import business.datahandler.URLClass;
-			import business.datahandler.did.DeviceInfoReader;
+			//import business.datahandler.did.DeviceInfoReader;
 			
 			import events.BusyIndicatorEventEpisode;
 			import events.NotConnectedEvent;
@@ -68,7 +68,7 @@ USA
 			
 			private var tTip:ToolTipReader = ToolTipReader.getInstance();
 			
-			private var dInfo:DeviceInfoReader = DeviceInfoReader.getInstance();
+			//private var dInfo:DeviceInfoReader = DeviceInfoReader.getInstance();
 			
 			[Bindable]
 			private var xTooltip:int;
@@ -91,7 +91,7 @@ USA
 				textinput_search.addEventListener(FocusEvent.FOCUS_OUT, handleFocusOut);
 
 				tTip.setDisplay(String(this.navigator.width), String(this.navigator.height));
-				dInfo.setDisplay(String(this.navigator.width), String(this.navigator.height));
+				//dInfo.setDisplay(String(this.navigator.width), String(this.navigator.height));
 
 				this.addEventListener(BusyIndicatorEventEpisode.INDICATORLOADED, loadIndicator);
 				
@@ -103,7 +103,7 @@ USA
 				setPosition();
 				
 				tTip.readFile();
-				dInfo.readFile();
+				//dInfo.readFile();
 				
 				if(connection.visible)
 					xmlData.setXMLListCollection(new XMLListCollection());
@@ -119,10 +119,12 @@ USA
 					tooltip.visible = true;	
 				}
 				
+				/*
 				if(dInfo.getStatus() != true)
 				{
 					dInfo.setFile();
 				}
+				*/
 				
 				//this.addEventListener("keyDown", handleButtons, false, 1);
 				//this.addEventListener("keyUp", handleButtons, false, 1);

--- a/src/views/SeriesView.mxml
+++ b/src/views/SeriesView.mxml
@@ -36,7 +36,7 @@ USA
 			import business.datahandler.EpisodesDataHandler;
 			import business.datahandler.SeriesDataHandler;
 			import business.datahandler.URLClass;
-			import business.datahandler.did.DeviceInfoReader;
+			//import business.datahandler.did.DeviceInfoReader;
 			
 			import events.BusyIndicatorEventSeries;
 			import events.ChangeTabViewEvent;
@@ -69,7 +69,7 @@ USA
 			
 			private var tTip:ToolTipReader = ToolTipReader.getInstance();
 			
-			private var dInfo:DeviceInfoReader = DeviceInfoReader.getInstance();
+			//private var dInfo:DeviceInfoReader = DeviceInfoReader.getInstance();
 
 			[Bindable]
 			private var xTooltip:int;
@@ -92,12 +92,12 @@ USA
 				textinput_search.addEventListener(FocusEvent.FOCUS_OUT, handleFocusOut);	
 
 				tTip.setDisplay(String(this.navigator.width), String(this.navigator.height));
-				dInfo.setDisplay(String(this.navigator.width), String(this.navigator.height));
+				//dInfo.setDisplay(String(this.navigator.width), String(this.navigator.height));
 				
 				setPosition();
 				
 				tTip.readFile();
-				dInfo.readFile();
+				//dInfo.readFile();
 				
 				if(connection.visible)
 					xmlData.setXMLListCollection(new XMLListCollection());
@@ -113,10 +113,12 @@ USA
 					tooltip.visible = true;	
 				}
 				
+				/*
 				if(dInfo.getStatus() != true)
 				{
 					dInfo.setFile();
 				}
+				*/
 				
 				this.addEventListener(KeyboardEvent.KEY_DOWN, handleButtons, false, 0, true);
 				this.addEventListener(KeyboardEvent.KEY_UP, handleButtons, false, 0, true);


### PR DESCRIPTION
Hi Leo,
this patch simplifies the URL verification. This makes it hopefully possible to use Matterhorn2Go with Matterhorn installations which are only reachable via HTTPS and with Matterhorn installations which are hooked into a regular webserver in a way that they are reachable via a subpath [http://example.com/path/to/matterhorn/<services>].

It's untested as I have no installed Flex but the changes are simple enough so that they sould hopefully work out of the box :-)

Take them or reject them as you wish.
Lars
